### PR TITLE
ci: pin the actions to commit SHAs and narrow the job token

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# Keep the SHA-pinned GitHub Actions current. The workflow `uses:` refs are
+# pinned to commit SHAs (with a trailing version comment) for supply-chain
+# safety; Dependabot opens a PR to bump the SHA + comment when a new release
+# of an action ships, so pinning doesn't freeze us on a stale, unpatched
+# action. Scoped to github-actions only — the npm dependency bumps of this
+# repo are driven by `scripts/update-repo.sh` in the workspace, not here.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,3 +1,16 @@
+# PR gate: install, build the package, build the docs, run the suite.
+#
+# The `uses:` refs are pinned to commit SHAs with a trailing version comment,
+# not to floating major tags: a tag is mutable, so `@v7` would silently follow
+# whatever that tag points at if an action's repo were ever compromised. The
+# cost of pinning is going stale, which `.github/dependabot.yml` pays — it
+# opens one grouped PR when a new release ships.
+#
+# `permissions: contents: read` is stated even though it is the account-wide
+# default, so the job keeps the narrow token if that default ever changes, and
+# `persist-credentials: false` keeps the token out of the runner's git config:
+# nothing here pushes, so nothing here needs to be able to.
+
 name: npm test
 
 on:
@@ -9,12 +22,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test_pull_request:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'


### PR DESCRIPTION
`actions/checkout@v3` and `actions/setup-node@v3` were four majors behind, and GitHub was already warning on every run that their Node 20 runtime is deprecated and being force-run on Node 24.

**What changed**

- both actions bumped to the current majors and **pinned to commit SHAs** with a trailing version comment (`# v7.0.1`, `# v7.0.0`), the pattern `octoscope` already uses — a major tag is mutable, so `@v7` follows wherever that tag is moved
- `.github/dependabot.yml` added, scoped to `github-actions` only: one grouped weekly PR bumps the SHAs, so pinning doesn't freeze us on an unpatched action
- `permissions: contents: read` stated explicitly, and `persist-credentials: false` on checkout — this job installs, builds and tests, it never pushes

**Compatibility, checked rather than assumed**

| Concern | Finding |
|---|---|
| `node-version-file`, `cache` still supported? | yes, both still inputs of `setup-node@v7` |
| setup-node v5/v6 caching breaking change | narrows *automatic* caching to npm; we pass `cache: 'yarn'` explicitly, unaffected |
| checkout v7 fork restriction | applies to `pull_request_target` / `workflow_run`; this workflow is `pull_request` |

Fleet-wide rollout of the change piloted in `gfazioli/mantine-spinner#36`, whose CI verified it green. All 27 repos carried a byte-identical workflow file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added weekly automated checks for updates to GitHub Actions.
  - Grouped related action updates for simpler maintenance.
  - Improved pull request workflow security with read-only access, immutable action versions, and disabled persisted credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->